### PR TITLE
feat: show member count in navigation on large viewports

### DIFF
--- a/src/components/MembersCount.astro
+++ b/src/components/MembersCount.astro
@@ -1,0 +1,24 @@
+---
+import { getEntry } from "astro:content";
+
+const memberCount = await getEntry("meetupStats", "memberCount");
+---
+
+<a
+  href="https://www.meetup.com/ottawa-forwardjs-meetup/"
+  target="_blank"
+  rel="noopener"
+  class="members-count">{memberCount.data.toLocaleString()} Members</a
+>
+
+<style>
+  .members-count {
+    font-weight: 600;
+  }
+
+  @media (max-width: 1000px) {
+    .members-count {
+      display: none;
+    }
+  }
+</style>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -1,5 +1,6 @@
 ---
 import logo from "../assets/forward.svg";
+import MembersCount from "./MembersCount.astro";
 ---
 
 <header>
@@ -36,6 +37,7 @@ import logo from "../assets/forward.svg";
         <li><a href="/jobs">Job Board</a></li>
       </ul>
     </div>
+    <MembersCount />
   </nav>
 </header>
 

--- a/src/content.config.js
+++ b/src/content.config.js
@@ -17,4 +17,14 @@ const projects = defineCollection({
   loader: file("./src/data/projects.json"),
 });
 
-export const collections = { pastEvents, upcomingEvents, jobs, projects };
+const meetupStats = defineCollection({
+  loader: file("./src/data/meetupStats.json"),
+});
+
+export const collections = {
+  pastEvents,
+  upcomingEvents,
+  jobs,
+  projects,
+  meetupStats,
+};

--- a/src/data/meetupStats.json
+++ b/src/data/meetupStats.json
@@ -1,0 +1,6 @@
+{
+  "memberCount": 2183,
+  "organizerCount": 8,
+  "averageEventRating": 4.78,
+  "totalEventRatings": 549
+}


### PR DESCRIPTION
This pull request adds a feature to display the number of community members on the ForwardJS website. The goal is to strengthen trust, create excitement for new members and site visitors, and highlight the ongoing growth of the ForwardJS community.

Please let me know if you’d like any changes to the design or data source. I’m totally open to feedback and suggestions!

